### PR TITLE
Remove proj definitions, clarify data types for ref.sys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- PROJ definitions have been removed as they have been deprecated by PROJ.
+
 ### Fixed
+
+- Clarified that EPSG codes must be numbers, PROJJSON must be objects and WKT2 must be a string.
 
 ## [v1.0.0] - 2021-03-08
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A spatial dimension in one of the horizontal (x or y) directions.
 | extent           | \[number]      | **REQUIRED.** Extent (lower and upper bounds) of the dimension as two-dimensional array. Open intervals with `null` are not allowed. |
 | values           | \[number]      | Optionally, a set of all potential values.                   |
 | step             | number\|null   | The space between the values. Use `null` for irregularly spaced steps. |
-| reference_system | string\|number\|object | The spatial reference system for the data, specified as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html), [PROJJSON](https://proj.org/specifications/projjson.html) or [PROJ definition](https://proj.org/usage/quickstart.html). Defaults to EPSG code 4326. |
+| reference_system | string\|number\|object | The spatial reference system for the data, specified as [numerical EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJJSON object](https://proj.org/specifications/projjson.html). Defaults to EPSG code 4326. |
 
 ### Vertical Spatial Dimension Object
 
@@ -61,7 +61,7 @@ A spatial dimension in vertical (z) direction.
 | values           | \[number\|string\] | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
 | step             | number\|null     | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string           | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
-| reference_system | string\|number\|object | The spatial reference system for the data, specified as [EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html), [PROJJSON](https://proj.org/specifications/projjson.html) or [PROJ definition](https://proj.org/usage/quickstart.html). Defaults to EPSG code 4326. |
+| reference_system | string\|number\|object | The spatial reference system for the data, specified as [numerical EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJJSON object](https://proj.org/specifications/projjson.html). Defaults to EPSG code 4326. |
 
 An Vertical Spatial Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both. 
 


### PR DESCRIPTION
### Removed

- PROJ definitions have been removed as they have been deprecated by PROJ.

### Fixed

- Clarified that EPSG codes must be numbers, PROJJSON must be objects and WKT2 must be a string.