### PR TITLE
Add cube:variables definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Added support for STAC 1.0
+- Updated examples to STAC 1.0.0
 - Added the `cube:variable` object for describing NetCDF-style multi-dimensional arrays in a datacube [#6](https://github.com/stac-extensions/datacube/pull/6)
 
 ### Deprecated

--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ A *Variable Object* defines a variable (or a multi-dimensional array). The varia
 | description      | string                       | Detailed multi-line description to explain the variable. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | extent           | \[number\|string\|null]      | If the variable consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
 | values           | \[number\|string]            | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
-| step             | number\|null                 | If the variable consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string                       | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 
 **type**: The Variable `type` indicates whether what kind of variable is being described. It has two allowed values:

--- a/README.md
+++ b/README.md
@@ -101,15 +101,15 @@ An Additional Dimension Object MUST specify an `extent` or a set of `values`. It
 
 A *Variable Object* defines a variable (or a multi-dimensional array). The variable may have dimensions, which are described by [Dimension Objects](#dimension-object).
 
-| Field Name       | Type                 | Description |
-| ---------------- | ---------------------| ----------- |
-| dimensions       | \[string]            | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
-| type             | string               | **REQUIRED.** Type of the variable, (`data`, `auxiliary`). |
-| description      | string               | Detailed multi-line description to explain the dimension. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
-| extent           | \[number\|null]      | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
-| values           | \[number\|string]    | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
-| step             | number\|null         | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
-| unit             | string               | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
+| Field Name       | Type                         | Description |
+| ---------------- | -----------------------------| ----------- |
+| dimensions       | \[string]                    | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
+| type             | string                       | **REQUIRED.** Type of the variable, either `data` or `auxiliary`. | 
+| description      | string                       | Detailed multi-line description to explain the dimension. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
+| extent           | \[number\|string\|null]      | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
+| values           | \[number\|string]            | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
+| step             | number\|null                 | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
+| unit             | string                       | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 
 **type**: The Variable `type` indicates whether what kind of variable is being described,
 using the terminology from the [CF Conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#terminology).

--- a/README.md
+++ b/README.md
@@ -111,24 +111,14 @@ A *Variable Object* defines a variable (or a multi-dimensional array). The varia
 | step             | number\|null                 | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string                       | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 
-**type**: The Variable `type` indicates whether what kind of variable is being described,
-using the terminology from the [CF Conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#terminology).
-A `data` variable typically represents some physical quantity being measured.
+**type**: The Variable `type` indicates whether what kind of variable is being described. It has two allowed values:
 
-An `auxiliary` coordinate variable is defined as
+1. `data`: a variable indicating some measured value, for example "precipitation", "temperature", etc.
+2. `auxiliary`: a variable that contains coordinate data, but isn't isn't a dimension in `cube:dimensions`.
+  For example, the values of the datacube might provided in the projected coordinate reference system, but
+  the datacube could have a variable `lon` with dimensions `(y, x)`, giving the longitude at each point.
 
-> Any netCDF variable that contains coordinate data, but is not a coordinate variable
-> (in the sense of that term defined by the NUG and used by this standard - see below).
-> Unlike coordinate variables, there is no relationship between the name of an
-> auxiliary coordinate variable and the name(s) of its dimension(s).
-
-For reference, a `coordinate` variable is defined as
-
-> a one-dimensional variable with the same name as its dimension `[e.g., time(time) ]`, and
-> it is defined as a numeric data type with values that are ordered monotonically.
-> Missing values are not allowed in coordinate variables.
-
-In the `datacube` STAC extension, coordinate variables should be provided by `cube:dimensions`.
+See the [CF Conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#terminology) for more on auxiliary coordinates.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ It specifies datacube related metadata, especially their dimensions and potentia
 These fields may be added to either [Item](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md) 
 Properties or a [Collection](https://github.com/radiantearth/stac-spec/tree/master/collection-spec/collection-spec.md).
 
-| Field Name      | Type                                               | Description                                 |
-| --------------- | -------------------------------------------------- | ------------------------------------------- |
-| cube:dimensions | Map<string, [Dimension Object](#dimension-object)> | **REQUIRED.** Uniquely named dimensions of the datacube. |
-| cube:variables  | Map<string, [Variable Object](#variable-object)>   | Data variables contained within the datacube. |
+| Field Name       | Type                                               | Description                                 |
+| ---------------- | -------------------------------------------------- | ------------------------------------------- |
+| cube:dimensions  | Map<string, [Dimension Object](#dimension-object)> | **REQUIRED.** Uniquely named dimensions of the datacube. |
+| cube:variables   | Map<string, [Variable Object](#variable-object)>   | Data variables contained within the datacube. |
 
 ### Dimension Object
 
@@ -35,7 +35,7 @@ certain values, too. `extent`, `values` and `step` share the same definition, bu
 depending on the type of dimension. Whenever it's useful to specify these fields, the objects add the additional fields `reference_system` 
 and `unit` with very similar definitions across the objects.
 
-#### Horizontal Spatial Dimension Object
+### Horizontal Spatial Dimension Object
 
 A spatial dimension in one of the horizontal (x or y) directions.
 
@@ -49,7 +49,7 @@ A spatial dimension in one of the horizontal (x or y) directions.
 | step             | number\|null   | The space between the values. Use `null` for irregularly spaced steps. |
 | reference_system | string\|number\|object | The spatial reference system for the data, specified as [numerical EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJJSON object](https://proj.org/specifications/projjson.html). Defaults to EPSG code 4326. |
 
-#### Vertical Spatial Dimension Object
+### Vertical Spatial Dimension Object
 
 A spatial dimension in vertical (z) direction.
 
@@ -66,7 +66,7 @@ A spatial dimension in vertical (z) direction.
 
 An Vertical Spatial Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both. 
 
-#### Temporal Dimension Object
+### Temporal Dimension Object
 
 A temporal dimension based on the ISO 8601 standard. The temporal reference system for the data is expected to be ISO 8601 compliant 
 (Gregorian calendar / UTC). Data not compliant with ISO 8601 can be represented as an *Additional Dimension Object* with `type` set to `temporal`.
@@ -79,7 +79,7 @@ A temporal dimension based on the ISO 8601 standard. The temporal reference syst
 | values     | \[string]       | If the dimension consists of set of specific values they can be listed here. The dates and/or times must be strings compliant to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601). |
 | step       | string\|null    | The space between the temporal instances as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `P1D`. Use `null` for irregularly spaced steps. |
 
-#### Additional Dimension Object
+### Additional Dimension Object
 
 An additional dimension that is not `spatial`, but may be `temporal` if the data is not compliant with ISO 8601.
 
@@ -92,7 +92,6 @@ An additional dimension that is not `spatial`, but may be `temporal` if the data
 | step             | number\|null      | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 | reference_system | string            | The reference system for the data.                           |
-| dimensions       | \[string]        | The dimensions of this dimension, for multidimensional coordinates. The values should be other keys in the ``cube:dimensions`` object, or be an empty list if this dimension does not have dimensions. See [multidimensional coordinates](#multidimensional-coordinates) |
 
 An Additional Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both.
 
@@ -100,41 +99,34 @@ An Additional Dimension Object MUST specify an `extent` or a set of `values`. It
 
 A *Variable Object* defines a variable (or a multi-dimensional array). The variable may have dimensions, which are described by [Dimension Objects](#dimension-object).
 
-| Field Name       | Type    | Description |
-| ---------------- | ------- | ----------- |
-| dimensions       | \[string] | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
-| description      | string  | Detailed multi-line description to explain the dimension. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
-| extent           | \[number\|null]   | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
-| values           | \[number\|string] | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
-| step             | number\|null      | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
-| unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
+| Field Name       | Type                 | Description |
+| ---------------- | ------- -------------| ----------- |
+| dimensions       | \[string]            | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
+| type             | string               | **REQUIRED.** Type of the variable, (`data`, `auxiliary`). |
+| description      | string               | Detailed multi-line description to explain the dimension. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
+| extent           | \[number\|null]      | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
+| values           | \[number\|string]    | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
+| step             | number\|null         | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
+| unit             | string               | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 
-### Multidimensional Coordinates
+**type**: The Variable `type` indicates whether what kind of variable is being described,
+using the terminology from the [CF Conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#terminology).
+A `data` variable typically represents some physical quantity being measured.
 
-The actual values of a dimension (a specific datetime or specific latitude, for example) can be referred
-to as "coordinates". Some dimensions might themselves be *multi-dimensional*, when the coordinates of that
-dimension depend on the values of one or more other dimensions. For example, a datacube might be defined
-in some geographic projection. The data provider might include a ``lat`` dimension, whose values depend
-on the ``(y, x)`` grid.
+An `auxiliary` coordinate variable is defined as
 
-```json
-{
-  "cube:dimensions": {
-    "x": {
-      ...
-    },
-    "y": {
-      ...
-    },
-    "lat": {
-      "type": "additional",
-      "description": "Latitude coordinate at a (y, x) point on the grid.",
-      "unit": "degrees_north",
-      "dimensions": ["y", "x"]
-    }
-  }
-}
-```
+> Any netCDF variable that contains coordinate data, but is not a coordinate variable
+> (in the sense of that term defined by the NUG and used by this standard - see below).
+> Unlike coordinate variables, there is no relationship between the name of an
+> auxiliary coordinate variable and the name(s) of its dimension(s).
+
+For reference, a `coordinate` variable is defined as
+
+> a one-dimensional variable with the same name as its dimension `[e.g., time(time) ]`, and
+> it is defined as a numeric data type with values that are ordered monotonically.
+> Missing values are not allowed in coordinate variables.
+
+In the `datacube` STAC extension, coordinate variables should be provided by `cube:dimensions`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Properties or a [Collection](https://github.com/radiantearth/stac-spec/tree/mast
 | Field Name      | Type                                               | Description                                 |
 | --------------- | -------------------------------------------------- | ------------------------------------------- |
 | cube:dimensions | Map<string, [Dimension Object](#dimension-object)> | **REQUIRED.** Uniquely named dimensions of the datacube. |
+| cube:variables  | Map<string, [Variable Object](#variable-object)>   | Data variables contained within the datacube. |
 
 ### Dimension Object
 
@@ -34,7 +35,7 @@ certain values, too. `extent`, `values` and `step` share the same definition, bu
 depending on the type of dimension. Whenever it's useful to specify these fields, the objects add the additional fields `reference_system` 
 and `unit` with very similar definitions across the objects.
 
-### Horizontal Spatial Dimension Object
+#### Horizontal Spatial Dimension Object
 
 A spatial dimension in one of the horizontal (x or y) directions.
 
@@ -48,7 +49,7 @@ A spatial dimension in one of the horizontal (x or y) directions.
 | step             | number\|null   | The space between the values. Use `null` for irregularly spaced steps. |
 | reference_system | string\|number\|object | The spatial reference system for the data, specified as [numerical EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJJSON object](https://proj.org/specifications/projjson.html). Defaults to EPSG code 4326. |
 
-### Vertical Spatial Dimension Object
+#### Vertical Spatial Dimension Object
 
 A spatial dimension in vertical (z) direction.
 
@@ -65,7 +66,7 @@ A spatial dimension in vertical (z) direction.
 
 An Vertical Spatial Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both. 
 
-### Temporal Dimension Object
+#### Temporal Dimension Object
 
 A temporal dimension based on the ISO 8601 standard. The temporal reference system for the data is expected to be ISO 8601 compliant 
 (Gregorian calendar / UTC). Data not compliant with ISO 8601 can be represented as an *Additional Dimension Object* with `type` set to `temporal`.
@@ -78,7 +79,7 @@ A temporal dimension based on the ISO 8601 standard. The temporal reference syst
 | values     | \[string]       | If the dimension consists of set of specific values they can be listed here. The dates and/or times must be strings compliant to [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601). |
 | step       | string\|null    | The space between the temporal instances as [ISO 8601 duration](https://en.wikipedia.org/wiki/ISO_8601#Durations), e.g. `P1D`. Use `null` for irregularly spaced steps. |
 
-### Additional Dimension Object
+#### Additional Dimension Object
 
 An additional dimension that is not `spatial`, but may be `temporal` if the data is not compliant with ISO 8601.
 
@@ -93,6 +94,19 @@ An additional dimension that is not `spatial`, but may be `temporal` if the data
 | reference_system | string            | The reference system for the data.                           |
 
 An Additional Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both.
+
+### Variable Object
+
+A *Variable Object* defines a multi-dimensional array. The array has dimensions, which are described by [Dimension Objects](#dimension-objet).
+
+| Field Name       | Type    | Description |
+| ---------------- | ------- | ----------- |
+| dimensions       | [ string ] | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
+| description      | string  | Detailed multi-line description to explain the dimension. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
+| extent           | \[number\|null]   | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
+| values           | \[number\|string] | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
+| step             | number\|null      | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
+| unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ An Additional Dimension Object MUST specify an `extent` or a set of `values`. It
 A *Variable Object* defines a variable (or a multi-dimensional array). The variable may have dimensions, which are described by [Dimension Objects](#dimension-object).
 
 | Field Name       | Type                 | Description |
-| ---------------- | ------- -------------| ----------- |
+| ---------------- | ---------------------| ----------- |
 | dimensions       | \[string]            | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
 | type             | string               | **REQUIRED.** Type of the variable, (`data`, `auxiliary`). |
 | description      | string               | Detailed multi-line description to explain the dimension. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,9 @@ Properties or a [Collection](https://github.com/radiantearth/stac-spec/tree/mast
 | Field Name       | Type                                               | Description                                 |
 | ---------------- | -------------------------------------------------- | ------------------------------------------- |
 | cube:dimensions  | Map<string, [Dimension Object](#dimension-object)> | **REQUIRED.** Uniquely named dimensions of the datacube. |
-| cube:variables   | Map<string, [Variable Object](#variable-object)>   | Data variables contained within the datacube. |
+| cube:variables   | Map<string, [Variable Object](#variable-object)>   | Uniquely named variables of the datacube. |
+
+The keys of `cube:dimensions` and `cube:variables` should be unique together; a key like `lat` should not be both a dimension and a variable.
 
 ### Dimension Object
 

--- a/README.md
+++ b/README.md
@@ -105,20 +105,21 @@ A *Variable Object* defines a variable (or a multi-dimensional array). The varia
 | ---------------- | -----------------------------| ----------- |
 | dimensions       | \[string]                    | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
 | type             | string                       | **REQUIRED.** Type of the variable, either `data` or `auxiliary`. | 
-| description      | string                       | Detailed multi-line description to explain the dimension. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
-| extent           | \[number\|string\|null]      | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
+| description      | string                       | Detailed multi-line description to explain the variable. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
+| extent           | \[number\|string\|null]      | If the variable consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
 | values           | \[number\|string]            | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
-| step             | number\|null                 | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
+| step             | number\|null                 | If the variable consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string                       | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 
 **type**: The Variable `type` indicates whether what kind of variable is being described. It has two allowed values:
 
 1. `data`: a variable indicating some measured value, for example "precipitation", "temperature", etc.
-2. `auxiliary`: a variable that contains coordinate data, but isn't isn't a dimension in `cube:dimensions`.
-  For example, the values of the datacube might provided in the projected coordinate reference system, but
+2. `auxiliary`: a variable that contains coordinate data, but isn't a dimension in `cube:dimensions`.
+  For example, the values of the datacube might be provided in the projected coordinate reference system, but
   the datacube could have a variable `lon` with dimensions `(y, x)`, giving the longitude at each point.
 
-See the [CF Conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#terminology) for more on auxiliary coordinates.
+See the [CF Conventions](http://cfconventions.org/Data/cf-conventions/cf-conventions-1.8/cf-conventions.html#terminology)
+for more on auxiliary coordinates.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -92,12 +92,13 @@ An additional dimension that is not `spatial`, but may be `temporal` if the data
 | step             | number\|null      | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 | reference_system | string            | The reference system for the data.                           |
+| dimensions       | [ string ]        | The dimensions of this dimension, for multidimensional coordinates. The values should be other keys in the ``cube:dimensions`` object, or be an empty list if this dimension does not have dimensions. See [multidimensional cooredinates](#multidimensional-coordinates)
 
 An Additional Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both.
 
 ### Variable Object
 
-A *Variable Object* defines a multi-dimensional array. The array has dimensions, which are described by [Dimension Objects](#dimension-objet).
+A *Variable Object* defines a variable (or a multi-dimensional array). The variable may have dimensions, which are described by [Dimension Objects](#dimension-objet).
 
 | Field Name       | Type    | Description |
 | ---------------- | ------- | ----------- |
@@ -107,6 +108,30 @@ A *Variable Object* defines a multi-dimensional array. The array has dimensions,
 | values           | \[number\|string] | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
 | step             | number\|null      | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
+
+
+### Multidimensional Coordinates
+
+The actual values of a dimension (a specific datetime or specific latitude, for example) can be referred to as "coordinates". Some dimensions might themselves be *multi-dimensional*, when the coordinates of that dimension depend on the values of one or more other dimensions. For example, a datacube might be defined in some geographic projection. The data provider might include a ``lat`` dimension, whose values depend on the ``(y, x)`` grid.
+
+```
+{
+  "cube:dimensions": {
+    "x": {
+      ...
+    },
+    "y": {
+      ...
+    },
+    "lat": {
+      "type": "additional",
+      "description": "Latitude coordinate at a (y, x) point on the grid.",
+      "unit": "degrees_north",
+      "dimensions": ["y", "x"]
+    }
+  }
+}
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -92,29 +92,32 @@ An additional dimension that is not `spatial`, but may be `temporal` if the data
 | step             | number\|null      | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 | reference_system | string            | The reference system for the data.                           |
-| dimensions       | [ string ]        | The dimensions of this dimension, for multidimensional coordinates. The values should be other keys in the ``cube:dimensions`` object, or be an empty list if this dimension does not have dimensions. See [multidimensional cooredinates](#multidimensional-coordinates)
+| dimensions       | \[string]        | The dimensions of this dimension, for multidimensional coordinates. The values should be other keys in the ``cube:dimensions`` object, or be an empty list if this dimension does not have dimensions. See [multidimensional coordinates](#multidimensional-coordinates) |
 
 An Additional Dimension Object MUST specify an `extent` or a set of `values`. It MAY specify both.
 
 ### Variable Object
 
-A *Variable Object* defines a variable (or a multi-dimensional array). The variable may have dimensions, which are described by [Dimension Objects](#dimension-objet).
+A *Variable Object* defines a variable (or a multi-dimensional array). The variable may have dimensions, which are described by [Dimension Objects](#dimension-object).
 
 | Field Name       | Type    | Description |
 | ---------------- | ------- | ----------- |
-| dimensions       | [ string ] | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
+| dimensions       | \[string] | **REQUIRED.** The dimensions of the variable. This should refer to keys in the ``cube:dimensions`` object or be an empty list if the variable has no dimensions. |
 | description      | string  | Detailed multi-line description to explain the dimension. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | extent           | \[number\|null]   | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-dimensional array. Use `null` for open intervals. |
 | values           | \[number\|string] | A set of all potential values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
 | step             | number\|null      | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
 | unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
 
-
 ### Multidimensional Coordinates
 
-The actual values of a dimension (a specific datetime or specific latitude, for example) can be referred to as "coordinates". Some dimensions might themselves be *multi-dimensional*, when the coordinates of that dimension depend on the values of one or more other dimensions. For example, a datacube might be defined in some geographic projection. The data provider might include a ``lat`` dimension, whose values depend on the ``(y, x)`` grid.
+The actual values of a dimension (a specific datetime or specific latitude, for example) can be referred
+to as "coordinates". Some dimensions might themselves be *multi-dimensional*, when the coordinates of that
+dimension depend on the values of one or more other dimensions. For example, a datacube might be defined
+in some geographic projection. The data provider might include a ``lat`` dimension, whose values depend
+on the ``(y, x)`` grid.
 
-```
+```json
 {
   "cube:dimensions": {
     "x": {

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
   ],

--- a/examples/daymet-hi-annual.json
+++ b/examples/daymet-hi-annual.json
@@ -33,10 +33,11 @@
     "data": {
       "href": "abfs://daymet-zarr/annual/hi.zarr",
       "title": "Annual Hawaii Daymet zarr root",
-      "description": "The root of the anuual Hawaii Daymet Zarr Group on Azure Blob Storage.",
+      "description": "The root of the annual Hawaii Daymet Zarr Group on Azure Blob Storage.",
       "roles": [
         "data",
-        "zarr-root"
+        "zarr-root",
+        "azure-blob-storge"
       ]
     }
   },
@@ -74,14 +75,16 @@
     },
     "nv": {
       "type": "count",
-      "description": "size of time_bnds",
+      "description": "Size of time_bnds.",
       "values": [
         0,
         1
       ]
-    },
+    }
+  },
+  "cube:variables": {
     "lat": {
-      "type": "latitude",
+      "type": "auxiliary",
       "extent": [
         17.960035,
         23.512327
@@ -94,7 +97,7 @@
       ]
     },
     "lon": {
-      "type": "latitude",
+      "type": "auxiliary",
       "extent": [
         -160.29884,
         -154.77806
@@ -105,10 +108,9 @@
         "y",
         "x"
       ]
-    }
-  },
-  "cube:variables": {
+    },
     "prcp": {
+      "type": "data",
       "description": "The total accumulated precipitation over the monthly period of the daily total precipitation. Sum of all forms of precipitation converted to a water-equivalent depth.",
       "extent": [
         0,
@@ -122,6 +124,7 @@
       ]
     },
     "swe": {
+      "type": "data",
       "description": "The average of the daily snow water equivalent (the amount of water contained within the snowpack) in kilograms per square meter over the monthly period.",
       "extent": [
         0,
@@ -135,6 +138,7 @@
       ]
     },
     "tmin": {
+      "type": "data",
       "description": "The average minimum temperature for a daily period over the entire monthly period.",
       "unit": "degrees C",
       "dimensions": [
@@ -144,6 +148,7 @@
       ]
     },
     "tmax": {
+      "type": "data",
       "description": "The average maximum temperature for a daily period over the entire monthly period.",
       "unit": "degrees C",
       "dimensions": [
@@ -153,6 +158,7 @@
       ]
     },
     "vp": {
+      "type": "data",
       "description": "The average of the daily average partial pressure of water vapor over the monthly period.",
       "unit": "Pa",
       "dimensions": [
@@ -162,7 +168,7 @@
       ]
     },
     "time_bnds": {
-      "type": "datetime",
+      "type": "data",
       "description": "",
       "dimensions": [
         "time",
@@ -170,7 +176,7 @@
       ]
     },
     "lambert_conformal_conic": {
-      "type": "projection",
+      "type": "data",
       "description": "Lambert Conformal Conic.",
       "values": [
         -32767

--- a/examples/daymet-hi-annual.json
+++ b/examples/daymet-hi-annual.json
@@ -1,180 +1,181 @@
 {
-    "type": "Collection",
-    "stac_version": "1.0.0-rc.3",
-    "stac_extensions": [
-        "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
-    ],
-    "id": "daymet-hi-annual",
-    "title": "Daymet Hawaii Annual",
-    "description": "Daymet is a data product derived from a collection of algorithms and computer software designed to interpolate and extrapolate from daily meteorological observations to produce gridded estimates of daily weather parameters. Weather parameters generated include daily surfaces of minimum and maximum temperature, precipitation, vapor pressure, radiation, snow water equivalent, and day length produced on a 1 km x 1 km gridded surface. The motivation for producing Daymet is to provide measurements of near-surface meteorological conditions where no instrumentation exists. Having estimates of these surfaces is critical to understanding many processes in the terrestrial biogeochemical system.",
-    "license": "proprietary",
-    "extent": {
-        "spatial": {
-            "bbox": [
-                [
-                    -160.3056,
-                    17.9539,
-                    -154.772,
-                    23.5186
-                ]
-            ]
-        },
-        "temporal": {
-            "interval": [
-                [
-                    "1980-01-01T12:00:00Z",
-                    "2019-12-31T12:00:00Z"
-                ]
-            ]
-        }
+  "type": "Collection",
+  "stac_version": "1.0.0-rc.3",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
+  ],
+  "id": "daymet-hi-annual",
+  "title": "Daymet Hawaii Annual",
+  "description": "Daymet is a data product derived from a collection of algorithms and computer software designed to interpolate and extrapolate from daily meteorological observations to produce gridded estimates of daily weather parameters. Weather parameters generated include daily surfaces of minimum and maximum temperature, precipitation, vapor pressure, radiation, snow water equivalent, and day length produced on a 1 km x 1 km gridded surface. The motivation for producing Daymet is to provide measurements of near-surface meteorological conditions where no instrumentation exists. Having estimates of these surfaces is critical to understanding many processes in the terrestrial biogeochemical system.",
+  "license": "proprietary",
+  "extent": {
+    "spatial": {
+      "bbox": [
+        [
+          -160.3056,
+          17.9539,
+          -154.772,
+          23.5186
+        ]
+      ]
     },
-    "links": [],
-    "assets": {
-        "data": {
-            "href": "abfs://daymet-zarr/annual/hi.zarr",
-            "title": "Annual Hawaii Daymet zarr root",
-            "description": "The root of the anuual Hawaii Daymet Zarr Group on Azure Blob Storage.",
-            "roles": [
-                "data", "zarr-root"
-            ]
-        }
+    "temporal": {
+      "interval": [
+        [
+          "1980-01-01T12:00:00Z",
+          "2019-12-31T12:00:00Z"
+        ]
+      ]
+    }
+  },
+  "links": [],
+  "assets": {
+    "data": {
+      "href": "abfs://daymet-zarr/annual/hi.zarr",
+      "title": "Annual Hawaii Daymet zarr root",
+      "description": "The root of the anuual Hawaii Daymet Zarr Group on Azure Blob Storage.",
+      "roles": [
+        "data",
+        "zarr-root"
+      ]
+    }
+  },
+  "cube:dimensions": {
+    "time": {
+      "type": "temporal",
+      "extent": [
+        "1980:00:00T00:00:00Z",
+        "2020:00:00T00:00:00Z"
+      ],
+      "description": "Annual",
+      "step": "P1Y"
     },
-    "cube:dimensions": {
-        "time": {
-            "type": "temporal",
-            "extent": [
-                "1980:00:00T00:00:00Z",
-                "2020:00:00T00:00:00Z"
-            ],
-            "description": "Annual",
-            "step": "P1Y"
-        },
-        "x": {
-            "type": "spatial",
-            "axis": "x",
-            "description": "North American Lambert Conformal Conic, 1KM grid.",
-            "extent": [
-                -622000,
-                -5519250
-            ],
-            "step": 1000,
-            "reference_system": "PROJCRS[\"undefined\",BASEGEOGCRS[\"undefined\",DATUM[\"undefined\",ELLIPSOID[\"undefined\",6378137,298.257223563,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8901]]],CONVERSION[\"unknown\",METHOD[\"Lambert Conic Conformal (2SP)\",ID[\"EPSG\",9802]],PARAMETER[\"Latitude of 1st standard parallel\",25,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8823]],PARAMETER[\"Latitude of 2nd standard parallel\",60,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8824]],PARAMETER[\"Latitude of false origin\",42.5,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8821]],PARAMETER[\"Longitude of false origin\",-100,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8822]],PARAMETER[\"Easting at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8826]],PARAMETER[\"Northing at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8827]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]"
-        },
-        "y": {
-            "type": "spatial",
-            "axis": "y",
-            "description": "North American Lambert Conformal Conic, 1KM grid.",
-            "extent": [
-                -5802250,
-                -39000
-            ],
-            "step": 1000,
-            "reference_system": "PROJCRS[\"undefined\",BASEGEOGCRS[\"undefined\",DATUM[\"undefined\",ELLIPSOID[\"undefined\",6378137,298.257223563,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8901]]],CONVERSION[\"unknown\",METHOD[\"Lambert Conic Conformal (2SP)\",ID[\"EPSG\",9802]],PARAMETER[\"Latitude of 1st standard parallel\",25,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8823]],PARAMETER[\"Latitude of 2nd standard parallel\",60,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8824]],PARAMETER[\"Latitude of false origin\",42.5,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8821]],PARAMETER[\"Longitude of false origin\",-100,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8822]],PARAMETER[\"Easting at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8826]],PARAMETER[\"Northing at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8827]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]"
-        },
-        "nv": {
-            "type": "count",
-            "description": "size of time_bnds",
-            "values": [
-                0,
-                1
-            ]
-        },
-        "lat": {
-            "type": "latitude",
-            "extent": [
-                17.960035,
-                23.512327
-            ],
-            "description": "latitude coordinate",
-            "unit": "degrees_north",
-            "dimensions": [
-                "y",
-                "x"
-            ]
-        },
-        "lon": {
-            "type": "latitude",
-            "extent": [
-                -160.29884,
-                -154.77806
-            ],
-            "description": "longitude coordinate",
-            "unit": "degrees_east",
-            "dimensions": [
-                "y",
-                "x"
-            ]
-        }
+    "x": {
+      "type": "spatial",
+      "axis": "x",
+      "description": "North American Lambert Conformal Conic, 1KM grid.",
+      "extent": [
+        -622000,
+        -5519250
+      ],
+      "step": 1000,
+      "reference_system": "PROJCRS[\"undefined\",BASEGEOGCRS[\"undefined\",DATUM[\"undefined\",ELLIPSOID[\"undefined\",6378137,298.257223563,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8901]]],CONVERSION[\"unknown\",METHOD[\"Lambert Conic Conformal (2SP)\",ID[\"EPSG\",9802]],PARAMETER[\"Latitude of 1st standard parallel\",25,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8823]],PARAMETER[\"Latitude of 2nd standard parallel\",60,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8824]],PARAMETER[\"Latitude of false origin\",42.5,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8821]],PARAMETER[\"Longitude of false origin\",-100,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8822]],PARAMETER[\"Easting at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8826]],PARAMETER[\"Northing at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8827]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]"
     },
-    "cube:variables": {
-        "prcp": {
-            "description": "The total accumulated precipitation over the monthly period of the daily total precipitation. Sum of all forms of precipitation converted to a water-equivalent depth.",
-            "extent": [
-                0,
-                null
-            ],
-            "unit": "mm",
-            "dimensions": [
-                "time",
-                "y",
-                "x"
-            ]
-        },
-        "swe": {
-            "description": "The average of the daily snow water equivalent (the amount of water contained within the snowpack) in kilograms per square meter over the monthly period.",
-            "extent": [
-                0,
-                null
-            ],
-            "unit": "kg/m2",
-            "dimensions": [
-                "time",
-                "y",
-                "x"
-            ]
-        },
-        "tmin": {
-            "description": "The average minimum temperature for a daily period over the entire monthly period.",
-            "extent": null,
-            "unit": "degrees C",
-            "dimensions": [
-                "time",
-                "y",
-                "x"
-            ]
-        },
-        "tmax": {
-            "description": "The average maximum temperature for a daily period over the entire monthly period.",
-            "extent": null,
-            "unit": "degrees C",
-            "dimensions": [
-                "time",
-                "y",
-                "x"
-            ]
-        },
-        "vp": {
-            "description": "The average of the daily average partial pressure of water vapor over the monthly period.",
-            "extent": null,
-            "unit": "Pa",
-            "dimensions": [
-                "time",
-                "y",
-                "x"
-            ]
-        },
-        "time_bnds": {
-            "type": "datetime",
-            "description": "",
-            "dimensions": [
-                "time",
-                "nv"
-            ]
-        },
-        "lambert_conformal_conic": {
-            "type": "projection?",
-            "description": "...",
-            "values": [
+    "y": {
+      "type": "spatial",
+      "axis": "y",
+      "description": "North American Lambert Conformal Conic, 1KM grid.",
+      "extent": [
+        -5802250,
+        -39000
+      ],
+      "step": 1000,
+      "reference_system": "PROJCRS[\"undefined\",BASEGEOGCRS[\"undefined\",DATUM[\"undefined\",ELLIPSOID[\"undefined\",6378137,298.257223563,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8901]]],CONVERSION[\"unknown\",METHOD[\"Lambert Conic Conformal (2SP)\",ID[\"EPSG\",9802]],PARAMETER[\"Latitude of 1st standard parallel\",25,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8823]],PARAMETER[\"Latitude of 2nd standard parallel\",60,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8824]],PARAMETER[\"Latitude of false origin\",42.5,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8821]],PARAMETER[\"Longitude of false origin\",-100,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8822]],PARAMETER[\"Easting at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8826]],PARAMETER[\"Northing at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8827]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]"
+    },
+    "nv": {
+      "type": "count",
+      "description": "size of time_bnds",
+      "values": [
+        0,
+        1
+      ]
+    },
+    "lat": {
+      "type": "latitude",
+      "extent": [
+        17.960035,
+        23.512327
+      ],
+      "description": "latitude coordinate",
+      "unit": "degrees_north",
+      "dimensions": [
+        "y",
+        "x"
+      ]
+    },
+    "lon": {
+      "type": "latitude",
+      "extent": [
+        -160.29884,
+        -154.77806
+      ],
+      "description": "longitude coordinate",
+      "unit": "degrees_east",
+      "dimensions": [
+        "y",
+        "x"
+      ]
+    }
+  },
+  "cube:variables": {
+    "prcp": {
+      "description": "The total accumulated precipitation over the monthly period of the daily total precipitation. Sum of all forms of precipitation converted to a water-equivalent depth.",
+      "extent": [
+        0,
+        null
+      ],
+      "unit": "mm",
+      "dimensions": [
+        "time",
+        "y",
+        "x"
+      ]
+    },
+    "swe": {
+      "description": "The average of the daily snow water equivalent (the amount of water contained within the snowpack) in kilograms per square meter over the monthly period.",
+      "extent": [
+        0,
+        null
+      ],
+      "unit": "kg/m2",
+      "dimensions": [
+        "time",
+        "y",
+        "x"
+      ]
+    },
+    "tmin": {
+      "description": "The average minimum temperature for a daily period over the entire monthly period.",
+      "extent": null,
+      "unit": "degrees C",
+      "dimensions": [
+        "time",
+        "y",
+        "x"
+      ]
+    },
+    "tmax": {
+      "description": "The average maximum temperature for a daily period over the entire monthly period.",
+      "extent": null,
+      "unit": "degrees C",
+      "dimensions": [
+        "time",
+        "y",
+        "x"
+      ]
+    },
+    "vp": {
+      "description": "The average of the daily average partial pressure of water vapor over the monthly period.",
+      "extent": null,
+      "unit": "Pa",
+      "dimensions": [
+        "time",
+        "y",
+        "x"
+      ]
+    },
+    "time_bnds": {
+      "type": "datetime",
+      "description": "",
+      "dimensions": [
+        "time",
+        "nv"
+      ]
+    },
+    "lambert_conformal_conic": {
+      "type": "projection?",
+      "description": "...",
+      "values": [
         -32767
       ],
       "dimensions": []

--- a/examples/daymet-hi-annual.json
+++ b/examples/daymet-hi-annual.json
@@ -172,7 +172,7 @@
     "lambert_conformal_conic": {
       "type": "projection",
       "description": "Lambert Conformal Conic.",
-      "values_numeric": [
+      "values": [
         -32767
       ],
       "dimensions": []

--- a/examples/daymet-hi-annual.json
+++ b/examples/daymet-hi-annual.json
@@ -1,0 +1,186 @@
+{
+    "type": "Collection",
+    "stac_version": "1.0.0-rc.3",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
+    ],
+    "id": "daymet-hi-annual",
+    "title": "Daymet Hawaii Annual",
+    "description": "Daymet is a data product derived from a collection of algorithms and computer software designed to interpolate and extrapolate from daily meteorological observations to produce gridded estimates of daily weather parameters. Weather parameters generated include daily surfaces of minimum and maximum temperature, precipitation, vapor pressure, radiation, snow water equivalent, and day length produced on a 1 km x 1 km gridded surface. The motivation for producing Daymet is to provide measurements of near-surface meteorological conditions where no instrumentation exists. Having estimates of these surfaces is critical to understanding many processes in the terrestrial biogeochemical system.",
+    "license": "proprietary",
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -160.3056,
+                    17.9539,
+                    -154.772,
+                    23.5186
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "1980-01-01T12:00:00Z",
+                    "2019-12-31T12:00:00Z"
+                ]
+            ]
+        }
+    },
+    "links": [],
+    "assets": {
+        "data": {
+            "href": "az://daymet-zarr/annual/hi.zarr",
+            "title": "Zarr store",
+            "type": "application/fsspec/zarr",
+            "description": "Root URL of the Zarr store",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "cube:dimensions": {
+        "time": {
+            "type": "temporal",
+            "extent": [
+                "1980:00:00T00:00:00Z",
+                "2020:00:00T00:00:00Z"
+            ],
+            "description": "Annual",
+            "step": "P1Y"
+        },
+        "x": {
+            "type": "spatial",
+            "axis": "x",
+            "description": "North American Lambert Conformal Conic, 1KM grid.",
+            "extent": [
+                -622000,
+                -5519250
+            ],
+            "step": 1000,
+            "reference_system": "PROJCRS[\"undefined\",BASEGEOGCRS[\"undefined\",DATUM[\"undefined\",ELLIPSOID[\"undefined\",6378137,298.257223563,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8901]]],CONVERSION[\"unknown\",METHOD[\"Lambert Conic Conformal (2SP)\",ID[\"EPSG\",9802]],PARAMETER[\"Latitude of 1st standard parallel\",25,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8823]],PARAMETER[\"Latitude of 2nd standard parallel\",60,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8824]],PARAMETER[\"Latitude of false origin\",42.5,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8821]],PARAMETER[\"Longitude of false origin\",-100,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8822]],PARAMETER[\"Easting at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8826]],PARAMETER[\"Northing at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8827]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]"
+        },
+        "y": {
+            "type": "spatial",
+            "axis": "y",
+            "description": "North American Lambert Conformal Conic, 1KM grid.",
+            "extent": [
+                -5802250,
+                -39000
+            ],
+            "step": 1000,
+            "reference_system": "PROJCRS[\"undefined\",BASEGEOGCRS[\"undefined\",DATUM[\"undefined\",ELLIPSOID[\"undefined\",6378137,298.257223563,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8901]]],CONVERSION[\"unknown\",METHOD[\"Lambert Conic Conformal (2SP)\",ID[\"EPSG\",9802]],PARAMETER[\"Latitude of 1st standard parallel\",25,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8823]],PARAMETER[\"Latitude of 2nd standard parallel\",60,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8824]],PARAMETER[\"Latitude of false origin\",42.5,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8821]],PARAMETER[\"Longitude of false origin\",-100,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8822]],PARAMETER[\"Easting at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8826]],PARAMETER[\"Northing at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8827]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]"
+        },
+        "nv": {
+            "type": "count?",
+            "description": "size of time_bnds",
+            "values": [
+                0,
+                1
+            ]
+        }
+    },
+    "cube:coordinates": {
+        "lat": {
+            "type": "latitude",
+            "extent": [
+                17.960035,
+                23.512327
+            ],
+            "description": "latitude coordinate",
+            "unit": "degrees_north",
+            "dimensions": [
+                "y",
+                "x"
+            ]
+        },
+        "lon": {
+            "type": "latitude",
+            "extent": [
+                -160.29884,
+                -154.77806
+            ],
+            "description": "longitude coordinate",
+            "unit": "degrees_east",
+            "dimensions": [
+                "y",
+                "x"
+            ]
+        }
+    },
+    "cube:variables": {
+        "prcp": {
+            "description": "The total accumulated precipitation over the monthly period of the daily total precipitation. Sum of all forms of precipitation converted to a water-equivalent depth.",
+            "extent": [
+                0,
+                null
+            ],
+            "unit": "mm",
+            "dimensions": [
+                "time",
+                "y",
+                "x"
+            ]
+        },
+        "swe": {
+            "description": "The average of the daily snow water equivalent (the amount of water contained within the snowpack) in kilograms per square meter over the monthly period.",
+            "extent": [
+                0,
+                null
+            ],
+            "unit": "kg/m2",
+            "dimensions": [
+                "time",
+                "y",
+                "x"
+            ]
+        },
+        "tmin": {
+            "description": "The average minimum temperature for a daily period over the entire monthly period.",
+            "extent": null,
+            "unit": "degrees C",
+            "dimensions": [
+                "time",
+                "y",
+                "x"
+            ]
+        },
+        "tmax": {
+            "description": "The average maximum temperature for a daily period over the entire monthly period.",
+            "extent": null,
+            "unit": "degrees C",
+            "dimensions": [
+                "time",
+                "y",
+                "x"
+            ]
+        },
+        "vp": {
+            "description": "The average of the daily average partial pressure of water vapor over the monthly period.",
+            "extent": null,
+            "unit": "Pa",
+            "dimensions": [
+                "time",
+                "y",
+                "x"
+            ]
+        },
+        "time_bnds": {
+            "type": "datetime",
+            "description": "",
+            "dimensions": [
+                "time",
+                "nv"
+            ]
+        },
+        "lambert_conformal_conic": {
+            "type": "projection?",
+            "description": "...",
+            "values": [
+        -32767
+      ],
+      "dimensions": []
+    }
+  }
+}

--- a/examples/daymet-hi-annual.json
+++ b/examples/daymet-hi-annual.json
@@ -31,12 +31,11 @@
     "links": [],
     "assets": {
         "data": {
-            "href": "az://daymet-zarr/annual/hi.zarr",
-            "title": "Zarr store",
-            "type": "application/fsspec/zarr",
-            "description": "Root URL of the Zarr store",
+            "href": "abfs://daymet-zarr/annual/hi.zarr",
+            "title": "Annual Hawaii Daymet zarr root",
+            "description": "The root of the anuual Hawaii Daymet Zarr Group on Azure Blob Storage.",
             "roles": [
-                "data"
+                "data", "zarr-root"
             ]
         }
     },
@@ -73,15 +72,13 @@
             "reference_system": "PROJCRS[\"undefined\",BASEGEOGCRS[\"undefined\",DATUM[\"undefined\",ELLIPSOID[\"undefined\",6378137,298.257223563,LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8901]]],CONVERSION[\"unknown\",METHOD[\"Lambert Conic Conformal (2SP)\",ID[\"EPSG\",9802]],PARAMETER[\"Latitude of 1st standard parallel\",25,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8823]],PARAMETER[\"Latitude of 2nd standard parallel\",60,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8824]],PARAMETER[\"Latitude of false origin\",42.5,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8821]],PARAMETER[\"Longitude of false origin\",-100,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8822]],PARAMETER[\"Easting at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8826]],PARAMETER[\"Northing at false origin\",0,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8827]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1,ID[\"EPSG\",9001]]]]"
         },
         "nv": {
-            "type": "count?",
+            "type": "count",
             "description": "size of time_bnds",
             "values": [
                 0,
                 1
             ]
-        }
-    },
-    "cube:coordinates": {
+        },
         "lat": {
             "type": "latitude",
             "extent": [

--- a/examples/daymet-hi-annual.json
+++ b/examples/daymet-hi-annual.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.3",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
   ],

--- a/examples/daymet-hi-annual.json
+++ b/examples/daymet-hi-annual.json
@@ -1,9 +1,9 @@
 {
-  "type": "Collection",
   "stac_version": "1.0.0-rc.3",
   "stac_extensions": [
     "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
   ],
+  "type": "Collection",
   "id": "daymet-hi-annual",
   "title": "Daymet Hawaii Annual",
   "description": "Daymet is a data product derived from a collection of algorithms and computer software designed to interpolate and extrapolate from daily meteorological observations to produce gridded estimates of daily weather parameters. Weather parameters generated include daily surfaces of minimum and maximum temperature, precipitation, vapor pressure, radiation, snow water equivalent, and day length produced on a 1 km x 1 km gridded surface. The motivation for producing Daymet is to provide measurements of near-surface meteorological conditions where no instrumentation exists. Having estimates of these surfaces is critical to understanding many processes in the terrestrial biogeochemical system.",
@@ -136,7 +136,6 @@
     },
     "tmin": {
       "description": "The average minimum temperature for a daily period over the entire monthly period.",
-      "extent": null,
       "unit": "degrees C",
       "dimensions": [
         "time",
@@ -146,7 +145,6 @@
     },
     "tmax": {
       "description": "The average maximum temperature for a daily period over the entire monthly period.",
-      "extent": null,
       "unit": "degrees C",
       "dimensions": [
         "time",
@@ -156,7 +154,6 @@
     },
     "vp": {
       "description": "The average of the daily average partial pressure of water vapor over the monthly period.",
-      "extent": null,
       "unit": "Pa",
       "dimensions": [
         "time",
@@ -173,8 +170,8 @@
       ]
     },
     "lambert_conformal_conic": {
-      "type": "projection?",
-      "description": "...",
+      "type": "projection",
+      "description": "Lambert Conformal Conic.",
       "values": [
         -32767
       ],

--- a/examples/daymet-hi-annual.json
+++ b/examples/daymet-hi-annual.json
@@ -172,7 +172,7 @@
     "lambert_conformal_conic": {
       "type": "projection",
       "description": "Lambert Conformal Conic.",
-      "values": [
+      "values_numeric": [
         -32767
       ],
       "dimensions": []

--- a/examples/item.json
+++ b/examples/item.json
@@ -99,6 +99,26 @@
       }
     }
   },
+  "cube:variables": {
+    "temp": {
+      "dimensions": [
+        "time",
+        "y",
+        "x",
+        "pressure_levels"
+      ],
+      "type": "data"
+    },
+    "color": {
+      "dimensions": [],
+      "type": "auxiliary",
+      "values": [
+        "red",
+        "green",
+        "blue"
+      ]
+    }
+  },
   "assets": {
     "data": {
       "href": "http://cool-sat.com/catalog/datacube-123/data.nc",

--- a/examples/item.json
+++ b/examples/item.json
@@ -1,5 +1,5 @@
 {
-  "stac_version": "1.0.0-rc.1",
+  "stac_version": "1.0.0",
   "stac_extensions": [
     "https://stac-extensions.github.io/datacube/v1.0.0/schema.json"
   ],

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -119,11 +119,7 @@
        "cube:variables": {
           "type": "object",
           "additionalProperties": {
-            "anyOf": [
-              {
-                "$ref": "#/definitions/variable"
-              }
-            ]
+              "$ref": "#/definitions/variable"
           }
         }
       }
@@ -323,8 +319,12 @@
         "dimensions"
       ],
       "properties": {
-        "type": {
-          "$ref": "#/definitions/variable_type"
+        "variable_type": {
+          "type": "string",
+          "enum": [
+            "data",
+            "auxiliary"
+          ]
         },
         "description": {
           "$ref": "#/definitions/description"
@@ -376,13 +376,6 @@
     "axis_z": {
       "type": "string",
       "const": "z"
-    },
-    "variable_type": {
-      "type": "string",
-      "enum": [
-        "data",
-        "auxiliary"
-      ]
     },
     "extent_closed": {
       "type": "array",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -28,10 +28,7 @@
                 {
                   "$ref": "#/definitions/datacube"
                 }
-              ],
-              "cube:variables": {
-                "$ref": "#/definitions/variable"
-              }
+              ]
             },
             "assets": {
               "type": "object",
@@ -58,9 +55,6 @@
           "properties": {
             "type": {
               "const": "Collection"
-            },
-            "cube:variables": {
-              "$ref": "#/definitions/variable"
             },
             "assets": {
               "type": "object",
@@ -122,7 +116,7 @@
             ]
           }
         },
-        "cube:variables": {
+       "cube:variables": {
           "type": "object",
           "additionalProperties": {
             "anyOf": [
@@ -329,6 +323,9 @@
         "dimensions"
       ],
       "properties": {
+        "type": {
+          "$ref": "#/definitions/variable_type"
+        },
         "description": {
           "$ref": "#/definitions/description"
         },
@@ -379,6 +376,13 @@
     "axis_z": {
       "type": "string",
       "const": "z"
+    },
+    "variable_type": {
+      "type": "string",
+      "enum": [
+        "data",
+        "auxiliary"
+      ]
     },
     "extent_closed": {
       "type": "array",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -187,6 +187,14 @@
         },
         "reference_system": {
           "type": "string"
+        },
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "type": [
+              "string"
+            ]
+          }
         }
       }
     },

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -22,8 +22,8 @@
               "allOf": [
                 {
                   "required": [
-                    // "cube:dimensions"
-                  
+                    "cube:dimensions"
+                  ]
                 },
                 {
                   "$ref": "#/definitions/datacube"

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -22,8 +22,8 @@
               "allOf": [
                 {
                   "required": [
-                    "cube:dimensions"
-                  ]
+                    // "cube:dimensions"
+                  
                 },
                 {
                   "$ref": "#/definitions/datacube"
@@ -344,6 +344,7 @@
           "items": {
             "type": [
               "string",
+              "number",
               "null"
             ]
           }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -353,7 +353,7 @@
         },
         "step": {
           "type": [
-            "string",
+            "number",
             "null"
           ]
         },

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -340,10 +340,7 @@
         },
         "values": {
           "type": "array",
-          "minItems": 1,
-          "items": {
-            "type": "string"
-          }
+          "minItems": 1
         },
         "extent": {
           "type": "array",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -28,7 +28,10 @@
                 {
                   "$ref": "#/definitions/datacube"
                 }
-              ]
+              ],
+              "cube:variables": {
+                "$ref": "#/definitions/variable"
+              }
             },
             "assets": {
               "type": "object",
@@ -55,6 +58,9 @@
           "properties": {
             "type": {
               "const": "Collection"
+            },
+            "cube:variables": {
+              "$ref": "#/definitions/variable"
             },
             "assets": {
               "type": "object",
@@ -112,6 +118,16 @@
               },
               {
                 "$ref": "#/definitions/temporal_dimension"
+              }
+            ]
+          }
+        },
+        "cube:variables": {
+          "type": "object",
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/variable"
               }
             ]
           }
@@ -295,6 +311,51 @@
             "string",
             "null"
           ]
+        }
+      }
+    },
+    "variable": {
+      "title": "Variable Object",
+      "type": "object",
+      "required": [
+        "dimensions"
+      ],
+      "properties": {
+        "description": {
+          "$ref": "#/definitions/description"
+        },
+        "dimensions": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "values": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "extent": {
+          "type": "array",
+          "minItems": 2,
+          "maxItems": 2,
+          "items": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
+        "step": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "unit": {
+          "$ref": "#/definitions/unit"
         }
       }
     },

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -351,12 +351,6 @@
             ]
           }
         },
-        "step": {
-          "type": [
-            "number",
-            "null"
-          ]
-        },
         "unit": {
           "$ref": "#/definitions/unit"
         }


### PR DESCRIPTION
Apologies for the WIP here, but I haven't worked with JSON schema or a STAC spec before and could use some help. I'll leave specific points inline, but a few general questions:

1. Is an optional `cube:variables` the right approach?
2. Are people OK with requiring `dimensions`, a list of strings, on each variable?

For reference, I'm trying this out on the daymet dataset. If you have xarray, zarr, and adlfs installed, this should work

```python
import fsspec
import xarray as xr

store = fsspec.get_mapper('az://daymet-zarr/daily/hi.zarr', account_name="daymeteuwest")
ds = xr.open_zarr(store, consolidated=True)

print(ds)
```

which prints out the repr

```
<xarray.Dataset>
Dimensions:                  (nv: 2, time: 14600, x: 284, y: 584)
Coordinates:
    lat                      (y, x) float32 dask.array<chunksize=(292, 284), meta=np.ndarray>
    lon                      (y, x) float32 dask.array<chunksize=(292, 284), meta=np.ndarray>
  * time                     (time) datetime64[ns] 1980-01-01T12:00:00 ... 20...
  * x                        (x) float32 -5.802e+06 -5.801e+06 ... -5.519e+06
  * y                        (y) float32 -3.9e+04 -4e+04 ... -6.21e+05 -6.22e+05
Dimensions without coordinates: nv
Data variables:
    dayl                     (time, y, x) float32 dask.array<chunksize=(365, 584, 284), meta=np.ndarray>
    lambert_conformal_conic  int16 ...
    prcp                     (time, y, x) float32 dask.array<chunksize=(365, 584, 284), meta=np.ndarray>
    srad                     (time, y, x) float32 dask.array<chunksize=(365, 584, 284), meta=np.ndarray>
    swe                      (time, y, x) float32 dask.array<chunksize=(365, 584, 284), meta=np.ndarray>
    time_bnds                (time, nv) datetime64[ns] dask.array<chunksize=(14600, 2), meta=np.ndarray>
    tmax                     (time, y, x) float32 dask.array<chunksize=(365, 584, 284), meta=np.ndarray>
    tmin                     (time, y, x) float32 dask.array<chunksize=(365, 584, 284), meta=np.ndarray>
    vp                       (time, y, x) float32 dask.array<chunksize=(365, 584, 284), meta=np.ndarray>
    yearday                  (time) int16 dask.array<chunksize=(14600,), meta=np.ndarray>
Attributes:
    Conventions:       CF-1.6
    Version_data:      Daymet Data Version 4.0
    Version_software:  Daymet Software Version 4.0
    citation:          Please see http://daymet.ornl.gov/ for current Daymet ...
    references:        Please see http://daymet.ornl.gov/ for current informa...
    source:            Daymet Software Version 4.0
    start_year:        [1980]
```

cc @m-mohr if you have a chance to provide feedback here I'd be extremely grateful.

Closes #1 