### PR TITLE
Make use of common metadata fields #22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Variables: Added `nodata` and `data_type` from
+  [common metadata](https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#data-values)
+
 ### Changed
 
 - Updated PROJJSON schema version from 0.4 to 0.7
@@ -55,6 +60,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Initial independent release, see [previous history](https://github.com/radiantearth/stac-spec/commits/v1.0.0-rc.1/extensions/datacube)
 
 ### Changed
+
 - Units for STAC dimensions should now be compliant to UDUNITS-2 units (singular) whenever available.
 
 [Unreleased]: <https://github.com/stac-extensions/datacube/compare/v2.2.0...HEAD>

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ A *Variable Object* defines a variable (or a multi-dimensional array). The varia
 | values           | \[number\|string]            | An (ordered) list of all values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
 | unit             | string                       | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) (unit symbol or singular unit name) or [UCUM](https://ucum.org). |
 | nodata           | number\|string               | Value used to identify no-data, see [common metadata](https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#no-data) for more details. |
-| nodata           | number\|string               | The data type of the values in the datacube, see [common metadata](https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#data-types) for more details. |
+| data_type        | string                       | The data type of the values in the datacube, see [common metadata](https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#data-types) for more details. |
 
 **type**: The Variable `type` indicates whether what kind of variable is being described. It has two allowed values:
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ A spatial dimension in vertical (z) direction.
 | extent           | \[number\|null\]   | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-element array. Use `null` for open intervals. |
 | values           | \[number\|string\] | An ordered list of all values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
 | step             | number\|null     | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
-| unit             | string           | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
+| unit             | string           | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) (unit symbol or singular unit name) or [UCUM](https://ucum.org). |
 | reference_system | string\|number\|object | The spatial reference system for the data and datacube metadata (`extent`, `values` and `step`), specified as [numerical EPSG code](http://www.epsg-registry.org/), [WKT2 (ISO 19162) string](http://docs.opengeospatial.org/is/18-010r7/18-010r7.html) or [PROJJSON object](https://proj.org/specifications/projjson.html). Defaults to EPSG code 4326. |
 
 A Vertical Spatial Dimension Object MUST specify an `extent` or `values`. It MAY specify both.
@@ -113,7 +113,7 @@ An additional dimension that is not `spatial`, but may be `temporal` if the data
 | extent           | \[number\|null]   | If the dimension consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-element array. Use `null` for open intervals. |
 | values           | \[number\|string] | An ordered list of all values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
 | step             | number\|null      | If the dimension consists of [interval](https://en.wikipedia.org/wiki/Level_of_measurement#Interval_scale) values, the space between the values. Use `null` for irregularly spaced steps. |
-| unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
+| unit             | string            | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) (unit symbol or singular unit name) or [UCUM](https://ucum.org). |
 | reference_system | string            | The reference system for the data and datacube metadata (`extent`, `values` and `step`). |
 
 An Additional Dimension Object MUST specify an `extent` or `values`. It MAY specify both.
@@ -134,7 +134,9 @@ A *Variable Object* defines a variable (or a multi-dimensional array). The varia
 | description      | string                       | Detailed multi-line description to explain the variable. [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich text representation. |
 | extent           | \[number\|string\|null]      | If the variable consists of [ordinal](https://en.wikipedia.org/wiki/Level_of_measurement#Ordinal_scale) values, the extent (lower and upper bounds) of the values as two-element array. Use `null` for open intervals. |
 | values           | \[number\|string]            | An (ordered) list of all values, especially useful for [nominal](https://en.wikipedia.org/wiki/Level_of_measurement#Nominal_level) values. |
-| unit             | string                       | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) units (singular). |
+| unit             | string                       | The unit of measurement for the data, preferably compliant to [UDUNITS-2](https://ncics.org/portfolio/other-resources/udunits2/) (unit symbol or singular unit name) or [UCUM](https://ucum.org). |
+| nodata           | number\|string               | Value used to identify no-data, see [common metadata](https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#no-data) for more details. |
+| nodata           | number\|string               | The data type of the values in the datacube, see [common metadata](https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#data-types) for more details. |
 
 **type**: The Variable `type` indicates whether what kind of variable is being described. It has two allowed values:
 

--- a/examples/item.json
+++ b/examples/item.json
@@ -106,7 +106,9 @@
           "x",
           "pressure_levels"
         ],
-        "type": "data"
+        "type": "data",
+        "nodata": "nan",
+        "data_type": "float32"
       },
       "color": {
         "dimensions": [],

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -531,6 +531,12 @@
         },
         "unit": {
           "$ref": "#/definitions/unit"
+        },
+        "nodata": {
+          "$ref": "#/definitions/nodata"
+        },
+        "data_type": {
+          "$ref": "#/definitions/data_type"
         }
       }
     },
@@ -596,7 +602,46 @@
       ]
     },
     "unit": {
+      "$comment": "The schema is from common metadata, see https://github.com/radiantearth/stac-spec/blob/v1.1.0/item-spec/json-schema/data-values.json",
       "type": "string"
+    },
+    "data_type": {
+      "$comment": "The schema is from common metadata, see https://github.com/radiantearth/stac-spec/blob/v1.1.0/item-spec/json-schema/data-values.json",
+      "type": "string",
+      "enum": [
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float16",
+        "float32",
+        "float64",
+        "cint16",
+        "cint32",
+        "cfloat32",
+        "cfloat64",
+        "other"
+      ]
+    },
+    "nodata": {
+      "$comment": "The schema is from common metadata, see https://github.com/radiantearth/stac-spec/blob/v1.1.0/item-spec/json-schema/data-values.json",
+      "oneOf": [
+        {
+          "type": "number"
+        },
+        {
+          "type": "string",
+          "enum": [
+            "nan",
+            "inf",
+            "-inf"
+          ]
+        }
+      ]
     },
     "reference_system_spatial": {
       "oneOf": [


### PR DESCRIPTION
Variables: Added `nodata` and `data_type` from
[common metadata](https://github.com/radiantearth/stac-spec/blob/v1.1.0/commons/common-metadata.md#data-values)